### PR TITLE
WASM conan configuration

### DIFF
--- a/conan-profiles/emscripten
+++ b/conan-profiles/emscripten
@@ -1,0 +1,19 @@
+[settings]
+os=Emscripten
+arch=wasm
+compiler=emcc
+compiler.version=4.0
+compiler.libcxx=libc++
+compiler.cppstd=20
+build_type=Release
+
+[buildenv]
+CC=emcc
+CXX=em++
+AR=emar
+RANLIB=emranlib
+CC_FOR_BUILD=/usr/bin/gcc
+CXX_FOR_BUILD=/usr/bin/g++
+CXXFLAGS=-fwasm-exceptions -fPIC -Wno-error=sign-compare
+CFLAGS=-fPIC
+LDFLAGS=-fwasm-exceptions


### PR DESCRIPTION
# Description

Adds a conan configuration for an emscripten build.

# Related issues

Follow-up per [this comment on Quantinnum/tket2#1415](https://github.com/Quantinuum/tket2/issues/1415#issuecomment-4865874941):

> I think the conan config would also be valuable, even if we don't depend on it for CI.